### PR TITLE
Replace em-dash by normal ascii dash to make it compile

### DIFF
--- a/src/com/swisscom/atclient/ATresponder.java
+++ b/src/com/swisscom/atclient/ATresponder.java
@@ -1760,7 +1760,7 @@ public class ATresponder extends Thread {
 			// signal via RSRP/RSRQ instead of legacy RSSI. Accept this when registered
 			// on LTE and capture AT+CESQ for actual signal quality diagnostics.
 			if (csqValue == 99 && startupRegistrationReady && startupNetworkReady && "4G/LTE".equals(startupRatLabel)) {
-				log.info("SIGNAL: CSQ 99 on LTE — accepting as ready (RSSI not populated on LTE). Capturing +CESQ for diagnostics.");
+				log.info("SIGNAL: CSQ 99 on LTE - accepting as ready (RSSI not populated on LTE). Capturing +CESQ for diagnostics.");
 				startupSignalReady = true;
 				watchdogList.set(4, "n/a");
 				watchdogList.set(5, "LTE");


### PR DESCRIPTION
Doesn't compile with javac 11.0.9.1:
```
./src/com/swisscom/atclient/ATresponder.java:1763: error: unmappable character (0xE2) for encoding US-ASCII
                                log.info("SIGNAL: CSQ 99 on LTE ??? accepting as ready (RSSI not populated on LTE). Capturing +CESQ for diagnostics.");
                                                                ^
```
Fixing by replacing the em-dash (added by AI?) with normal ASCII one.